### PR TITLE
Update download_linux.html.erb for RHEL/CentOS/etc.

### DIFF
--- a/app/views/downloads/download_linux.html.erb
+++ b/app/views/downloads/download_linux.html.erb
@@ -32,5 +32,8 @@
   
   <h3>OpenBSD</h3>
   <code>$ pkg_add git</code>
+  
+  <h3>Red Hat Enterprise Linux, Oracle Linux, CentOS, Scientific Linux, et al.</h3>
+  <p>RHEL and derivatives typically ship older versions of git.  If you cannot (or don't want to) compile git from source, you may need to use a 3rd-party repository such as <a href="https://ius.io/">the IUS Community Project</a> to obtain a more recent version of git.</p>
 
 </div>


### PR DESCRIPTION
There's absolutely no useful guidance for how to get git 2+ installed on RHEL et al, so this comment at least addresses the issue with a well-maintained and curated repo that won't break anyone's existing systems.
